### PR TITLE
Reintroduce loop tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,6 @@ before_install:
   - conda install -c https://conda.anaconda.org/treddy scipy
   - chmod +x ./
 script:
-  - travis_wait nosetests --cover-package voronoi_analysis_library --processes=2 --process-timeout=300 --with-coverage tests.py
+  - nosetests --with-coverage --cover-package voronoi_analysis_library --processes=2 --process-timeout=300 tests.py
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,6 @@ before_install:
   - conda install -c https://conda.anaconda.org/treddy scipy
   - chmod +x ./
 script:
-  - travis_wait nosetests --with-coverage --cover-package voronoi_analysis_library --processes=2 --process-timeout=300 tests.py 
+  - travis_wait nosetests --cover-package voronoi_analysis_library --processes=2 --process-timeout=300 --with-coverage tests.py
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,6 @@ before_install:
   - conda install -c https://conda.anaconda.org/treddy scipy
   - chmod +x ./
 script:
-  - nosetests --with-coverage --cover-package voronoi_analysis_library tests.py
+  - ./virus_nosetests --with-coverage --cover-package voronoi_analysis_library --processes=2 --process-timeout=300
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,6 @@ before_install:
   - conda install -c https://conda.anaconda.org/treddy scipy
   - chmod +x ./
 script:
-  - ./virus_nosetests --with-coverage --cover-package voronoi_analysis_library --processes=2 --process-timeout=300
+  - nosetests --with-coverage --cover-package voronoi_analysis_library tests.py
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,6 @@ before_install:
   - conda install -c https://conda.anaconda.org/treddy scipy
   - chmod +x ./
 script:
-  - nosetests --with-coverage --cover-package voronoi_analysis_library --processes=2 --process-timeout=300 tests.py
+  - nosetests --with-coverage --cover-package voronoi_analysis_library tests.py
 after_success:
   - coveralls

--- a/tests.py
+++ b/tests.py
@@ -271,7 +271,6 @@ class TestVoronoiAnalysisLoopControl(CommonTestsVoronoiAnalysisLoop,unittest.Tes
         self.assertGreaterEqual(outer_min, 99.0, "Outer leaflet % surface area reconsitution drops below 99%. Minimum value found was {mini}.".format(mini=outer_min))
         self.assertGreaterEqual(inner_min, 99.0, "Inner leaflet % surface area reconsitution drops below 99%. Minimum value found was {mini}.".format(mini=inner_min))
 
-#@unittest.skip("Temporarily disabled for Travis CI")
 #class TestVoronoiAnalysisLoopFlu(CommonTestsVoronoiAnalysisLoop,unittest.TestCase):
 #    '''Functional test(s) to ensure stability / correctness of the huge voronoi_analysis_library.voronoi_analysis_loop() function for FLU condition.'''
 #
@@ -308,42 +307,41 @@ class TestVoronoiAnalysisLoopControl(CommonTestsVoronoiAnalysisLoop,unittest.Tes
 #        np.testing.assert_array_less(np.zeros(sim39_outer_leaflet_protein_reconstitutions.shape), sim39_outer_leaflet_protein_reconstitutions, err_msg="The % surface area contribution from protein in flu simulations should always exceed 0 (outer leaflet)")
 #        np.testing.assert_array_less(np.zeros(sim39_inner_leaflet_protein_reconstitutions.shape), sim39_inner_leaflet_protein_reconstitutions, err_msg="The % surface area contribution from protein in flu simulations should always exceed 0 (inner leaflet)")
 #
-#@unittest.skip("Temporarily disabled for Travis CI")
-#class TestVoronoiAnalysisLoopDengue(CommonTestsVoronoiAnalysisLoop,unittest.TestCase):
-#    '''Functional test(s) to ensure stability / correctness of the huge voronoi_analysis_library.voronoi_analysis_loop() function for DENGUE condition.'''
-#
-#    @classmethod
-#    def setUpClass(cls):
-#        cls.u = MDAnalysis.Universe('dengue_final_snapshot_compact_no_solvent.gro.bz2') #dengue universe
-#        cls.d = TempDirectory()
-#        #create short trajectory for testing purposes
-#        cls.xtc = cls.d.path + '/dengue_dummy.xtc'
-#        cls.num_frames = 4
-#        with XTCWriter(cls.xtc, cls.u.trajectory.n_atoms) as W:
-#            while cls.num_frames > 0:
-#                W.write(cls.u)
-#                cls.num_frames -= 1
-#        cls.u_multiframe = MDAnalysis.Universe('dengue_final_snapshot_compact_no_solvent.gro.bz2', cls.xtc)
-#        cls.loop_result = voronoi_analysis_library.voronoi_analysis_loop(cls.u_multiframe,0,'full',1,proteins_present='yes',dengue_condition=1)
-#        cls.expected_keys = ['POPC', 'PPCE', 'DPPE', 'CER', 'DUPC', 'DOPS', 'PPCS', 'protein']
-#        cls.dictionary_headgroup_data = cls.loop_result[5]
-#        cls.dict_test_key = 'PPCE'
-#
-#    def test_surface_area_reconstitution_dengue(self):
-#        '''Various checks for surface area reconstitution properties of the dengue virion condition.'''
-#        dengue_outer_leaflet_lipid_reconstitutions = np.array(self.loop_result[1])
-#        dengue_outer_leaflet_protein_reconstitutions = np.array(self.loop_result[2])
-#        dengue_inner_leaflet_lipid_reconstitutions = np.array(self.loop_result[3])
-#        dengue_inner_leaflet_protein_reconstitutions = np.array(self.loop_result[4])
-#
-#        np.testing.assert_allclose(dengue_outer_leaflet_lipid_reconstitutions + dengue_outer_leaflet_protein_reconstitutions, np.zeros(dengue_outer_leaflet_lipid_reconstitutions.shape) + 100., rtol=1e-07, err_msg="Total % reconstitution of surface area in outer leaflet is not close to 100.")
-#        np.testing.assert_allclose(dengue_inner_leaflet_lipid_reconstitutions + dengue_inner_leaflet_protein_reconstitutions, np.zeros(dengue_inner_leaflet_lipid_reconstitutions.shape) + 100., rtol=1e-01, err_msg="Total % reconstitution of surface area in inner leaflet is not close to 100.")
-#
-#        np.testing.assert_array_less(dengue_outer_leaflet_protein_reconstitutions, dengue_outer_leaflet_lipid_reconstitutions, err_msg="For dengue simulations, the % SA reconstitution from protein should always be less than the contribution from lipid (outer leaflet).")
-#        np.testing.assert_array_less(dengue_inner_leaflet_protein_reconstitutions, dengue_inner_leaflet_lipid_reconstitutions, err_msg="For dengue simulations, the % SA reconstitution from protein should always be less than the contribution from lipid (inner leaflet).")
-#
-#        np.testing.assert_array_less(np.zeros(dengue_outer_leaflet_protein_reconstitutions.shape), dengue_outer_leaflet_protein_reconstitutions, err_msg="The % surface area contribution from protein in dengue simulations should always exceed 0 (outer leaflet)")
-#        np.testing.assert_array_less(np.zeros(dengue_inner_leaflet_protein_reconstitutions.shape), dengue_inner_leaflet_protein_reconstitutions, err_msg="The % surface area contribution from protein in dengue simulations should always exceed 0 (inner leaflet)")
+class TestVoronoiAnalysisLoopDengue(CommonTestsVoronoiAnalysisLoop,unittest.TestCase):
+    '''Functional test(s) to ensure stability / correctness of the huge voronoi_analysis_library.voronoi_analysis_loop() function for DENGUE condition.'''
+
+    @classmethod
+    def setUpClass(cls):
+        cls.u = MDAnalysis.Universe('dengue_final_snapshot_compact_no_solvent.gro.bz2') #dengue universe
+        cls.d = TempDirectory()
+        #create short trajectory for testing purposes
+        cls.xtc = cls.d.path + '/dengue_dummy.xtc'
+        cls.num_frames = 4
+        with XTCWriter(cls.xtc, cls.u.trajectory.n_atoms) as W:
+            while cls.num_frames > 0:
+                W.write(cls.u)
+                cls.num_frames -= 1
+        cls.u_multiframe = MDAnalysis.Universe('dengue_final_snapshot_compact_no_solvent.gro.bz2', cls.xtc)
+        cls.loop_result = voronoi_analysis_library.voronoi_analysis_loop(cls.u_multiframe,0,'full',1,proteins_present='yes',dengue_condition=1)
+        cls.expected_keys = ['POPC', 'PPCE', 'DPPE', 'CER', 'DUPC', 'DOPS', 'PPCS', 'protein']
+        cls.dictionary_headgroup_data = cls.loop_result[5]
+        cls.dict_test_key = 'PPCE'
+
+    def test_surface_area_reconstitution_dengue(self):
+        '''Various checks for surface area reconstitution properties of the dengue virion condition.'''
+        dengue_outer_leaflet_lipid_reconstitutions = np.array(self.loop_result[1])
+        dengue_outer_leaflet_protein_reconstitutions = np.array(self.loop_result[2])
+        dengue_inner_leaflet_lipid_reconstitutions = np.array(self.loop_result[3])
+        dengue_inner_leaflet_protein_reconstitutions = np.array(self.loop_result[4])
+
+        np.testing.assert_allclose(dengue_outer_leaflet_lipid_reconstitutions + dengue_outer_leaflet_protein_reconstitutions, np.zeros(dengue_outer_leaflet_lipid_reconstitutions.shape) + 100., rtol=1e-07, err_msg="Total % reconstitution of surface area in outer leaflet is not close to 100.")
+        np.testing.assert_allclose(dengue_inner_leaflet_lipid_reconstitutions + dengue_inner_leaflet_protein_reconstitutions, np.zeros(dengue_inner_leaflet_lipid_reconstitutions.shape) + 100., rtol=1e-01, err_msg="Total % reconstitution of surface area in inner leaflet is not close to 100.")
+
+        np.testing.assert_array_less(dengue_outer_leaflet_protein_reconstitutions, dengue_outer_leaflet_lipid_reconstitutions, err_msg="For dengue simulations, the % SA reconstitution from protein should always be less than the contribution from lipid (outer leaflet).")
+        np.testing.assert_array_less(dengue_inner_leaflet_protein_reconstitutions, dengue_inner_leaflet_lipid_reconstitutions, err_msg="For dengue simulations, the % SA reconstitution from protein should always be less than the contribution from lipid (inner leaflet).")
+
+        np.testing.assert_array_less(np.zeros(dengue_outer_leaflet_protein_reconstitutions.shape), dengue_outer_leaflet_protein_reconstitutions, err_msg="The % surface area contribution from protein in dengue simulations should always exceed 0 (outer leaflet)")
+        np.testing.assert_array_less(np.zeros(dengue_inner_leaflet_protein_reconstitutions.shape), dengue_inner_leaflet_protein_reconstitutions, err_msg="The % surface area contribution from protein in dengue simulations should always exceed 0 (inner leaflet)")
 
 class TestVoronoiAreaDict(unittest.TestCase):
 

--- a/tests.py
+++ b/tests.py
@@ -271,42 +271,42 @@ class TestVoronoiAnalysisLoopControl(CommonTestsVoronoiAnalysisLoop,unittest.Tes
         self.assertGreaterEqual(outer_min, 99.0, "Outer leaflet % surface area reconsitution drops below 99%. Minimum value found was {mini}.".format(mini=outer_min))
         self.assertGreaterEqual(inner_min, 99.0, "Inner leaflet % surface area reconsitution drops below 99%. Minimum value found was {mini}.".format(mini=inner_min))
 
-#class TestVoronoiAnalysisLoopFlu(CommonTestsVoronoiAnalysisLoop,unittest.TestCase):
-#    '''Functional test(s) to ensure stability / correctness of the huge voronoi_analysis_library.voronoi_analysis_loop() function for FLU condition.'''
-#
-#    @classmethod
-#    def setUpClass(cls):
-#        cls.u = MDAnalysis.Universe('sim39_final_snapshot_compact_no_solvent.gro.bz2') #actual flu universe
-#        cls.d = TempDirectory()
-#        #create short trajectory for testing purposes
-#        cls.xtc = cls.d.path +  '/flu_dummy.xtc'
-#        cls.num_frames = 4
-#        with XTCWriter(cls.xtc, cls.u.trajectory.n_atoms) as W:
-#            while cls.num_frames > 0:
-#                W.write(cls.u)
-#                cls.num_frames -= 1
-#        cls.u_multiframe = MDAnalysis.Universe('sim39_final_snapshot_compact_no_solvent.gro.bz2', cls.xtc)
-#        cls.loop_result = voronoi_analysis_library.voronoi_analysis_loop(cls.u_multiframe,0,'full',1,PPCH_PO4_threshold=275,proteins_present='yes',FORS_present='yes')
-#        cls.expected_keys = ['POPS', 'DOPE', 'CHOL', 'PPCH', 'DOPX', 'FORS', 'protein']
-#        cls.dictionary_headgroup_data = cls.loop_result[5]
-#        cls.dict_test_key = 'CHOL'
-#
-#    def test_surface_area_reconstitution_flu(self):
-#        '''Various checks for surface area reconstitution properties of the flu virion condition.'''
-#        sim39_outer_leaflet_lipid_reconstitutions = np.array(self.loop_result[1])
-#        sim39_outer_leaflet_protein_reconstitutions = np.array(self.loop_result[2])
-#        sim39_inner_leaflet_lipid_reconstitutions = np.array(self.loop_result[3])
-#        sim39_inner_leaflet_protein_reconstitutions = np.array(self.loop_result[4])
-#        
-#        np.testing.assert_allclose(sim39_outer_leaflet_lipid_reconstitutions + sim39_outer_leaflet_protein_reconstitutions, np.zeros(sim39_outer_leaflet_lipid_reconstitutions.shape) + 100., rtol=1e-07, err_msg="Total % reconstitution of surface area in outer leaflet is not close to 100.")
-#        np.testing.assert_allclose(sim39_inner_leaflet_lipid_reconstitutions + sim39_inner_leaflet_protein_reconstitutions, np.zeros(sim39_inner_leaflet_lipid_reconstitutions.shape) + 100., rtol=1e-01, err_msg="Total % reconstitution of surface area in inner leaflet is not close to 100.")
-#
-#        np.testing.assert_array_less(sim39_outer_leaflet_protein_reconstitutions, sim39_outer_leaflet_lipid_reconstitutions, err_msg="For flu simulations, the % SA reconstitution from protein should always be less than the contribution from lipid (outer leaflet).")
-#        np.testing.assert_array_less(sim39_inner_leaflet_protein_reconstitutions, sim39_inner_leaflet_lipid_reconstitutions, err_msg="For flu simulations, the % SA reconstitution from protein should always be less than the contribution from lipid (inner leaflet).")
-#
-#        np.testing.assert_array_less(np.zeros(sim39_outer_leaflet_protein_reconstitutions.shape), sim39_outer_leaflet_protein_reconstitutions, err_msg="The % surface area contribution from protein in flu simulations should always exceed 0 (outer leaflet)")
-#        np.testing.assert_array_less(np.zeros(sim39_inner_leaflet_protein_reconstitutions.shape), sim39_inner_leaflet_protein_reconstitutions, err_msg="The % surface area contribution from protein in flu simulations should always exceed 0 (inner leaflet)")
-#
+class TestVoronoiAnalysisLoopFlu(CommonTestsVoronoiAnalysisLoop,unittest.TestCase):
+    '''Functional test(s) to ensure stability / correctness of the huge voronoi_analysis_library.voronoi_analysis_loop() function for FLU condition.'''
+
+    @classmethod
+    def setUpClass(cls):
+        cls.u = MDAnalysis.Universe('sim39_final_snapshot_compact_no_solvent_small_proteins_retained.gro.bz2') #actual flu universe
+        cls.d = TempDirectory()
+        #create short trajectory for testing purposes
+        cls.xtc = cls.d.path +  '/flu_dummy.xtc'
+        cls.num_frames = 4
+        with XTCWriter(cls.xtc, cls.u.trajectory.n_atoms) as W:
+            while cls.num_frames > 0:
+                W.write(cls.u)
+                cls.num_frames -= 1
+        cls.u_multiframe = MDAnalysis.Universe('sim39_final_snapshot_compact_no_solvent_small_proteins_retained.gro.bz2', cls.xtc)
+        cls.loop_result = voronoi_analysis_library.voronoi_analysis_loop(cls.u_multiframe,0,'full',1,PPCH_PO4_threshold=275,proteins_present='yes',FORS_present='yes')
+        cls.expected_keys = ['POPS', 'DOPE', 'CHOL', 'PPCH', 'DOPX', 'FORS', 'protein']
+        cls.dictionary_headgroup_data = cls.loop_result[5]
+        cls.dict_test_key = 'CHOL'
+
+    def test_surface_area_reconstitution_flu(self):
+        '''Various checks for surface area reconstitution properties of the flu virion condition.'''
+        sim39_outer_leaflet_lipid_reconstitutions = np.array(self.loop_result[1])
+        sim39_outer_leaflet_protein_reconstitutions = np.array(self.loop_result[2])
+        sim39_inner_leaflet_lipid_reconstitutions = np.array(self.loop_result[3])
+        sim39_inner_leaflet_protein_reconstitutions = np.array(self.loop_result[4])
+        
+        np.testing.assert_allclose(sim39_outer_leaflet_lipid_reconstitutions + sim39_outer_leaflet_protein_reconstitutions, np.zeros(sim39_outer_leaflet_lipid_reconstitutions.shape) + 100., rtol=1e-07, err_msg="Total % reconstitution of surface area in outer leaflet is not close to 100.")
+        np.testing.assert_allclose(sim39_inner_leaflet_lipid_reconstitutions + sim39_inner_leaflet_protein_reconstitutions, np.zeros(sim39_inner_leaflet_lipid_reconstitutions.shape) + 100., rtol=1e-01, err_msg="Total % reconstitution of surface area in inner leaflet is not close to 100.")
+
+        np.testing.assert_array_less(sim39_outer_leaflet_protein_reconstitutions, sim39_outer_leaflet_lipid_reconstitutions, err_msg="For flu simulations, the % SA reconstitution from protein should always be less than the contribution from lipid (outer leaflet).")
+        np.testing.assert_array_less(sim39_inner_leaflet_protein_reconstitutions, sim39_inner_leaflet_lipid_reconstitutions, err_msg="For flu simulations, the % SA reconstitution from protein should always be less than the contribution from lipid (inner leaflet).")
+
+        np.testing.assert_array_less(np.zeros(sim39_outer_leaflet_protein_reconstitutions.shape), sim39_outer_leaflet_protein_reconstitutions, err_msg="The % surface area contribution from protein in flu simulations should always exceed 0 (outer leaflet)")
+        np.testing.assert_array_less(np.zeros(sim39_inner_leaflet_protein_reconstitutions.shape), sim39_inner_leaflet_protein_reconstitutions, err_msg="The % surface area contribution from protein in flu simulations should always exceed 0 (inner leaflet)")
+
 class TestVoronoiAnalysisLoopDengue(CommonTestsVoronoiAnalysisLoop,unittest.TestCase):
     '''Functional test(s) to ensure stability / correctness of the huge voronoi_analysis_library.voronoi_analysis_loop() function for DENGUE condition.'''
 

--- a/tests.py
+++ b/tests.py
@@ -242,36 +242,35 @@ class CommonTestsVoronoiAnalysisLoop(object):
         self.assertTrue(list_percent_SA_reconstitution.count(list_percent_SA_reconstitution[0]) == len(list_percent_SA_reconstitution), "Not all surface area reconstitution values are the same for each frame, despite identical coordinates for each input frame in test trajectory.")
         self.assertTrue(list_percent_SA_reconstitution_2.count(list_percent_SA_reconstitution_2[0]) == len(list_percent_SA_reconstitution_2), "Not all surface area reconstitution values are the same for each frame, despite identical coordinates for each input frame in test trajectory.")
 
-#@unittest.skip("Temporarily disabled for Travis CI")
-#class TestVoronoiAnalysisLoopControl(CommonTestsVoronoiAnalysisLoop,unittest.TestCase):
-#    '''Functional test(s) to ensure stability / correctness of the huge voronoi_analysis_library.voronoi_analysis_loop() function for CONTROL condition.'''
-#
-#    @classmethod
-#    def setUpClass(cls):
-#        cls.u = MDAnalysis.Universe('control_traj_2.gro') #mock flu universe with DOPE/X and POPS inner leaflet; PPCH / CHOL outer leaflet; no protein
-#        cls.d = TempDirectory()
-#        #create short trajectory for testing purposes
-#        cls.xtc = cls.d.path + '/control_traj_2_dummy.xtc'
-#        cls.num_frames = 4
-#        with XTCWriter(cls.xtc, cls.u.trajectory.n_atoms) as W:
-#            while cls.num_frames > 0:
-#                W.write(cls.u)
-#                cls.num_frames -= 1
-#        cls.u_multiframe = MDAnalysis.Universe('control_traj_2.gro', cls.xtc)
-#        cls.loop_result = voronoi_analysis_library.voronoi_analysis_loop(cls.u_multiframe,0,'full',1,control_condition=1)
-#        cls.expected_keys = ['POPS', 'DOPE', 'CHOL', 'PPCH', 'DOPX']
-#        cls.dictionary_headgroup_data = cls.loop_result[3]
-#        cls.dict_test_key = 'CHOL'
-#
-#    def test_surface_area_reconstitution(self):
-#        '''For a control system with no proteins we should achive > 99% surface area reconstitution in all frames.'''
-#        array_outer_leaflet_percent_SA_reconstitution = np.array(self.loop_result[1])
-#        array_inner_leaflet_percent_SA_reconstitution = np.array(self.loop_result[2])
-#        outer_min = array_outer_leaflet_percent_SA_reconstitution.min()
-#        inner_min = array_inner_leaflet_percent_SA_reconstitution.min()
-#        self.assertGreaterEqual(outer_min, 99.0, "Outer leaflet % surface area reconsitution drops below 99%. Minimum value found was {mini}.".format(mini=outer_min))
-#        self.assertGreaterEqual(inner_min, 99.0, "Inner leaflet % surface area reconsitution drops below 99%. Minimum value found was {mini}.".format(mini=inner_min))
-#
+class TestVoronoiAnalysisLoopControl(CommonTestsVoronoiAnalysisLoop,unittest.TestCase):
+    '''Functional test(s) to ensure stability / correctness of the huge voronoi_analysis_library.voronoi_analysis_loop() function for CONTROL condition.'''
+
+    @classmethod
+    def setUpClass(cls):
+        cls.u = MDAnalysis.Universe('control_traj_2_small.gro.bz2') #mock flu universe with DOPE/X and POPS inner leaflet; PPCH / CHOL outer leaflet; no protein
+        cls.d = TempDirectory()
+        #create short trajectory for testing purposes
+        cls.xtc = cls.d.path + '/control_traj_2_dummy.xtc'
+        cls.num_frames = 4
+        with XTCWriter(cls.xtc, cls.u.trajectory.n_atoms) as W:
+            while cls.num_frames > 0:
+                W.write(cls.u)
+                cls.num_frames -= 1
+        cls.u_multiframe = MDAnalysis.Universe('control_traj_2_small.gro.bz2', cls.xtc)
+        cls.loop_result = voronoi_analysis_library.voronoi_analysis_loop(cls.u_multiframe,0,'full',1,control_condition=1)
+        cls.expected_keys = ['POPS', 'DOPE', 'CHOL', 'PPCH', 'DOPX']
+        cls.dictionary_headgroup_data = cls.loop_result[3]
+        cls.dict_test_key = 'CHOL'
+
+    def test_surface_area_reconstitution(self):
+        '''For a control system with no proteins we should achive > 99% surface area reconstitution in all frames.'''
+        array_outer_leaflet_percent_SA_reconstitution = np.array(self.loop_result[1])
+        array_inner_leaflet_percent_SA_reconstitution = np.array(self.loop_result[2])
+        outer_min = array_outer_leaflet_percent_SA_reconstitution.min()
+        inner_min = array_inner_leaflet_percent_SA_reconstitution.min()
+        self.assertGreaterEqual(outer_min, 99.0, "Outer leaflet % surface area reconsitution drops below 99%. Minimum value found was {mini}.".format(mini=outer_min))
+        self.assertGreaterEqual(inner_min, 99.0, "Inner leaflet % surface area reconsitution drops below 99%. Minimum value found was {mini}.".format(mini=inner_min))
+
 #@unittest.skip("Temporarily disabled for Travis CI")
 #class TestVoronoiAnalysisLoopFlu(CommonTestsVoronoiAnalysisLoop,unittest.TestCase):
 #    '''Functional test(s) to ensure stability / correctness of the huge voronoi_analysis_library.voronoi_analysis_loop() function for FLU condition.'''

--- a/virus_nosetests
+++ b/virus_nosetests
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+import nose
+nose.run()

--- a/virus_nosetests
+++ b/virus_nosetests
@@ -1,3 +1,0 @@
-#!/usr/bin/env python
-import nose
-nose.run()


### PR DESCRIPTION
Restoration of the testing code that probes `voronoi_analysis_loop` code, while retaining reasonably fast Travis-CI performance and restoring proper coverage reports.
